### PR TITLE
Phonon workflow

### DIFF
--- a/carmm/phonon/post_process.py
+++ b/carmm/phonon/post_process.py
@@ -18,8 +18,6 @@ def get_band_conf(atoms):
                 cor2 = lat1.special_points[sp][1]
                 cor3 = lat1.special_points[sp][2]
                 band.append(f'{cor1} {cor2} {cor3}')
-        # elif sp == ',':
-        #     band[-1] = band[-1] + ','
 
     for i in band_label:
         if i == ',':
@@ -41,10 +39,8 @@ def get_band_conf(atoms):
             f'BAND_LABELS = {band_label_final}\n'
             f'BAND_POINTS = 101\n')
     f.close()
-    # f.write(f'TPROP =.TRUE.\n'
-    #         f'MESH = 16 16 16\n')
 
-def get_thermal_conf(atoms):
+def get_thermal_conf():
     f = open('thermal.conf', 'w')
     f.write(f'TPROP =.TRUE.\n'
             f'MESH = 16 16 16\n')

--- a/carmm/phonon/post_process.py
+++ b/carmm/phonon/post_process.py
@@ -1,0 +1,100 @@
+def get_band_conf(atoms):
+    lat1 = atoms.cell.bandpath()
+    band_label = []
+    band = []
+    for sp in lat1.path:
+        if sp == 'G':
+            band_label.append('$\\Gamma$')
+        elif sp.isnumeric():
+            band_label[-1] = band_label[-1] + sp
+        else:
+            band_label.append(sp)
+    for sp in band_label:
+        if sp != ',':
+            if sp == '$\\Gamma$':
+                band.append('0 0 0')
+            else:
+                cor1 = lat1.special_points[sp][0]
+                cor2 = lat1.special_points[sp][1]
+                cor3 = lat1.special_points[sp][2]
+                band.append(f'{cor1} {cor2} {cor3}')
+        # elif sp == ',':
+        #     band[-1] = band[-1] + ','
+
+    for i in band_label:
+        if i == ',':
+            band_label.pop(band_label.index(i))
+
+    band_label_final = ' '.join(band_label)
+    print(band_label_final)
+    band_final = '    '.join(band)
+    print(band_final)
+
+    try:
+        f = open('band.conf', 'x')
+        f.close()
+    except:
+        print()
+
+    f = open('band.conf', 'w')
+    f.write(f'BAND = {band_final}\n'
+            f'BAND_LABELS = {band_label_final}\n'
+            f'BAND_POINTS = 101\n')
+    f.close()
+    # f.write(f'TPROP =.TRUE.\n'
+    #         f'MESH = 16 16 16\n')
+
+def get_thermal_conf(atoms):
+    f = open('thermal.conf', 'w')
+    f.write(f'TPROP =.TRUE.\n'
+            f'MESH = 16 16 16\n')
+    f.close()
+
+def generate_phonon_data():
+    import os
+    os.system("phonopy -f disp-?/aims.out")
+    os.system("phonopy -p -s band.conf")
+    os.system("phonopy -p -s thermal.conf")
+
+def phonon_data_to_csv(band_data=False, thermal_data=True, band_file='band.yaml', thermal_file='thermal_properties.yaml'):
+    import yaml
+    from yaml import load
+    from yaml import CLoader as Loader
+    import os
+    import csv
+    if thermal_data:
+        if os.path.exists(thermal_file):
+            property_list = ['Energy (kJ/mol)', 'Entropy (J/K/mol)', 'Helmholtz free energy (kJ/mol)', 'Heat Capacity (J/K/mol)']
+            header = ['Temperature (K)']+property_list
+            csv_file = f'thermal_data.csv'
+            with open(csv_file, mode='w', newline='') as file:
+                writer = csv.writer(file)
+                writer.writerow(header)
+                stream = open(thermal_file, 'r')
+                dictionary = yaml.load(stream, Loader)
+                for data in dictionary['thermal_properties']:
+                    writer.writerow([data['temperature'], data['energy'], data['entropy'], data['free_energy'],
+                                     data['heat_capacity']])
+                stream.close()
+                print('Thermal data written to file thermal_data.csv')
+        else:
+            raise Exception('The file \'thermal_properties.yaml\' not found. Make sure you are providiing the correct file name to the '
+                  'thermal_file parameter in the function')
+    if band_data:
+        if os.path.exists(band_file):
+            csv_file = f'band_data.csv'
+            with open(csv_file, mode='w', newline='') as file:
+                stream = open(band_file, 'r')
+                dictionary = yaml.load(stream, Loader)
+                freqencies_header = [f'frequency {i+1}' for i in range(len(dictionary['phonon'][0]['band']))]
+                header = ['q-position[0]', 'q-position[1]', 'q-position[2]', 'Distance']+freqencies_header
+                writer = csv.writer(file)
+                writer.writerow(header)
+                for key in dictionary['phonon']:
+                    row = [key['q-position'][i] for i in range(3)]+[key['distance']]+[j['frequency']for j in key['band']]
+                    writer.writerow(row)
+                stream.close()
+                print('Phonon band structure data written to file band_data.csv')
+        else:
+            raise Exception('The file \'band.yaml\' not found. Make sure you are providiing the correct file name to the '
+                  'band_file parameter in the function')

--- a/carmm/phonon/post_process.py
+++ b/carmm/phonon/post_process.py
@@ -40,17 +40,20 @@ def get_band_conf(atoms):
             f'BAND_POINTS = 101\n')
     f.close()
 
+
 def get_thermal_conf():
     f = open('thermal.conf', 'w')
     f.write(f'TPROP =.TRUE.\n'
             f'MESH = 16 16 16\n')
     f.close()
 
+
 def generate_phonon_data():
     import os
     os.system("phonopy -f disp-?/aims.out")
     os.system("phonopy -p -s band.conf")
     os.system("phonopy -p -s thermal.conf")
+
 
 def phonon_data_to_csv(band_data=False, thermal_data=True, band_file='band.yaml', thermal_file='thermal_properties.yaml'):
     import yaml
@@ -74,8 +77,8 @@ def phonon_data_to_csv(band_data=False, thermal_data=True, band_file='band.yaml'
                 stream.close()
                 print('Thermal data written to file thermal_data.csv')
         else:
-            raise Exception('The file \'thermal_properties.yaml\' not found. Make sure you are providiing the correct file name to the '
-                  'thermal_file parameter in the function')
+            raise Exception('The file \'thermal_properties.yaml\' not found. Make sure you are providing the correct '
+                            'file name to the thermal_file parameter in the function')
     if band_data:
         if os.path.exists(band_file):
             csv_file = f'band_data.csv'
@@ -92,5 +95,5 @@ def phonon_data_to_csv(band_data=False, thermal_data=True, band_file='band.yaml'
                 stream.close()
                 print('Phonon band structure data written to file band_data.csv')
         else:
-            raise Exception('The file \'band.yaml\' not found. Make sure you are providiing the correct file name to the '
-                  'band_file parameter in the function')
+            raise Exception('The file \'band.yaml\' not found. Make sure you are providing the correct file name to '
+                  'the band_file parameter in the function')

--- a/carmm/phonon/pre_process.py
+++ b/carmm/phonon/pre_process.py
@@ -1,0 +1,77 @@
+def make_displaced_supercells(atoms_object, supercell_size:[1,1,1], displacement: 0.01):
+    '''
+
+    '''
+    import numpy as np
+    from phonopy import Phonopy
+    from phonopy.interface.calculator import read_crystal_structure, write_crystal_structure
+    import yaml
+    from yaml import CLoader as Loader
+
+    sup_matrix = np.diag(supercell_size)
+    print(sup_matrix.shape)
+    atoms_object.write('geometry_eq.in')
+    unitcell, optional_structure_info = read_crystal_structure("geometry_eq.in", interface_mode='aims')
+    det = np.round(np.linalg.det(sup_matrix))
+    phonon = Phonopy(unitcell, supercell_matrix=sup_matrix)
+
+    phonon.generate_displacements(distance=displacement)
+    supercells = phonon.supercells_with_displacements
+    phonon.save('phonopy_disp.yaml')
+    stream = open("phonopy_disp.yaml", 'r')
+    dictionary = yaml.load(stream, Loader)
+    stream.close()
+    dictionary['phonopy'].update([('calculator', 'aims'), ('configuration', {'create_displacements': '".true."', 'dim':
+        f'{supercell_size[0]} {supercell_size[1]} {supercell_size[2]}', 'calculator': '"aims"'})])
+    # dictionary['physical_unit'].update([('length', '"angstrom"'), ('force_constants', '"eV/angstrom^2"')])
+    with open('phonopy_disp.yaml', 'w') as f:
+        data = yaml.dump(dictionary, f, sort_keys=False)
+
+    return det, supercells
+
+
+def get_charges_and_moments(determinant, atoms_object):
+    charges_sup = []
+    moments_sup = []
+
+    charges = atoms_object.get_initial_charges()
+    moments = atoms_object.get_initial_magnetic_moments()
+
+    for i in range(len(atoms_object)):
+        for j in range(int(determinant)):
+            charges_sup.append(charges[i])
+            moments_sup.append(moments[i])
+
+    return moments_sup, charges_sup
+
+
+def creating_files_and_directories(supercells, charges, moments):
+    '''
+
+    :param atoms_object:
+    :param charges:
+    :param moments:
+    :return:
+    '''
+
+
+    import os
+    import shutil
+    from phonopy.interface.calculator import write_crystal_structure
+    from ase.io import read
+    for ind, sup in enumerate(supercells):
+        write_crystal_structure(f"geometry_{ind+1:03}.in", supercells[ind], interface_mode='aims')
+        atoms = read(f"geometry_{ind+1:03}.in")
+        atoms.set_initial_charges(charges)
+        atoms.set_initial_magnetic_moments(moments)
+        directory = f"disp-{ind+1:03}"
+        parent_dir = os.getcwd()
+        path_final = os.path.join(parent_dir, directory)
+        if os.path.exists(path_final):
+            shutil.rmtree(path_final)
+        os.mkdir(path_final)
+        atoms.write(path_final + '/geometry.in')
+        shutil.copy(parent_dir + '/input.py', path_final + '/input.py')
+        shutil.copy(parent_dir + '/submission.script', path_final + '/submission.script')
+        os.chdir(parent_dir)
+        os.remove(f"geometry_{ind+1:03}.in")


### PR DESCRIPTION
The functionality makes use of the phonopy API to create displaced geometry structures in separate files (with correct charges and moments on individual atoms). Having performed first-principles calculations on these displaced structure to compute the forces, the functionality also allows a seamless post-processing involving compilation of FORCE_SETS, generating phonon band structure, computing thermal properties and then saving all the data in .csv file allowing further flexibility to the user.

Currently, the workflow relies on the user performing first-principles/force-field calculations on individual displaced structures. The functionality can take care of pre- and post-processing.

TODOs:

- sort out issues with wildcards on Windows
- doc strings for the functions
- create an example
- incorporating the option to run the calculation on a supercomputer (provided the user has a venv with phonopy installed)
- the supercomputer option will have a bottleneck of how many calculations on displaced structure can be performed --> can use something like taskfarm to manage this?